### PR TITLE
Enable WebAC for Fedora

### DIFF
--- a/fcrepo/4.7.4-demo/Dockerfile
+++ b/fcrepo/4.7.4-demo/Dockerfile
@@ -42,6 +42,6 @@ RUN apk update && \
 
 
 
-COPY WEB-INF/* ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/
+COPY WEB-INF/ ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/
 
 ENTRYPOINT [ "/bin/entrypoint.sh" ]

--- a/fcrepo/4.7.4-demo/Dockerfile
+++ b/fcrepo/4.7.4-demo/Dockerfile
@@ -1,13 +1,13 @@
 FROM tomcat:8.5.24-jre8-alpine
 
-ENV FCREPO_VERSION=4.7.4 \
+ENV FCREPO_VERSION=4.7.5 \
 FCREPO_HOST=localhost \
 FCREPO_PORT=8080 \
 FCREPO_JMS_PORT=61616 \
 FCREPO_STOMP_PORT=61613 \
 FCREPO_CONTEXT_PATH=/fcrepo \
 FCREPO_LOG_LEVEL=INFO \
-FCREPO_MODESHAPE_CONFIGURATION=classpath:/config/file-simple/repository.json \
+FCREPO_MODESHAPE_CONFIGURATION=classpath:/config/servlet-auth/repository.json \
 ACTIVEMQ_BROKER_URI=tcp://localhost:61616 \
 FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/config/activemq.xml \
 FCREPO_SPRING_CONFIGURATION=classpath:/spring/master.xml \
@@ -24,10 +24,10 @@ RUN apk update && \
     apk add --no-cache ca-certificates wget gettext curl && \
     export FCREPO_WAR=fcrepo-webapp-${FCREPO_VERSION}.war && \ 
     wget -O ${CATALINA_HOME}/webapps/fcrepo.war \
-    http://central.maven.org/maven2/org/fcrepo/fcrepo-webapp/4.7.4/fcrepo-webapp-4.7.4.war && \
+    http://central.maven.org/maven2/org/fcrepo/fcrepo-webapp-plus/${FCREPO_VERSION}/fcrepo-webapp-plus-${FCREPO_VERSION}.war && \
     #https://github.com/fcrepo4-exts/fcrepo-webapp-plus/releases/download/fcrepo-webapp-plus-${FCREPO_VERSION}/fcrepo-webapp-plus-webac-${FCREPO_VERSION}.war && \
-    #echo "6c66d18aa2f3813bae69d2dc16a00fbebf9366d3 *${CATALINA_HOME}/webapps/fcrepo.war" \
-    #    | sha1sum -c -  && \
+    echo "95cd04e17eebfc9af5dd7a0968293f92bfd75bf0 *${CATALINA_HOME}/webapps/fcrepo.war" \
+        | sha1sum -c -  && \
     echo "org.apache.catalina.webresources.Cache.level = SEVERE" \
       >> ${CATALINA_HOME}/conf/logging.properties && \
     mkdir ${CATALINA_HOME}/webapps/fcrepo && \
@@ -36,8 +36,10 @@ RUN apk update && \
     chmod 700 /bin/entrypoint.sh && \
     chmod 700 /bin/setup_fedora.sh && \
     /bin/entrypoint.sh startup.sh && \
-    /bin/setup_fedora.sh http://localhost:${FCREPO_PORT}/${FCREPO_CONTEXT_PATH}/rest && \
-    ${CATALINA_HOME}/bin/shutdown.sh
+    /bin/setup_fedora.sh http://127.0.0.1:${FCREPO_PORT}/${FCREPO_CONTEXT_PATH}/rest && \
+    ${CATALINA_HOME}/bin/shutdown.sh && \
+    sed -i '/bootstrap/d' conf/tomcat-users.xml
+
 
 
 COPY WEB-INF/* ${CATALINA_HOME}/webapps/fcrepo/WEB-INF/

--- a/fcrepo/4.7.4-demo/WEB-INF/classes/spring/auth-repo.xml
+++ b/fcrepo/4.7.4-demo/WEB-INF/classes/spring/auth-repo.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <!-- Context that supports the actual ModeShape JCR itself -->
+
+    <context:annotation-config/>
+
+    <bean name="modeshapeRepofactory"
+        class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
+        p:repositoryConfiguration="${fcrepo.modeshape.configuration}"
+        depends-on="authenticationProvider"/>
+
+    <!-- Optional PrincipalProvider that will inspect the request header, "some-header", for user role values -->
+    <bean name="headerProvider" class="org.fcrepo.auth.common.HttpHeaderPrincipalProvider">
+      <property name="headerName" value="some-header"/>
+      <property name="separator" value=","/>
+    </bean>
+
+    <bean name="containerRolesProvider" class="org.fcrepo.auth.common.ContainerRolesPrincipalProvider">
+      <property name="roleNames">
+        <util:set set-class="java.util.HashSet">
+          <value>fedoraUser</value>
+        </util:set>
+      </property>
+    </bean>
+
+    <bean name="delegatedPrincipalProvider" class="org.fcrepo.auth.common.DelegateHeaderPrincipalProvider"/>
+
+    <util:set id="principalProviderSet">
+      <ref bean="headerProvider"/>
+      <ref bean="delegatedPrincipalProvider"/>
+      <ref bean="containerRolesProvider"/>
+    </util:set>
+
+    <bean name="fad" class="org.fcrepo.auth.webac.WebACAuthorizationDelegate"/>
+
+    <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
+
+    <bean name="authenticationProvider" class="org.fcrepo.auth.common.ServletContainerAuthenticationProvider">
+      <property name="fad" ref="fad"/>
+      <property name="principalProviders" ref="principalProviderSet"/>
+    </bean>
+
+    <bean class="org.modeshape.jcr.ModeShapeEngine" init-method="start"/>
+
+    <!-- For the time being, load annotation config here too -->
+    <bean class="org.fcrepo.metrics.MetricsConfig"/>
+
+    <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager" />
+
+</beans>

--- a/fcrepo/4.7.4-demo/WEB-INF/web.xml
+++ b/fcrepo/4.7.4-demo/WEB-INF/web.xml
@@ -9,7 +9,7 @@
 
         <context-param>
                 <param-name>contextConfigLocation</param-name>
-                <param-value>WEB-INF/classes/spring/master.xml</param-value>
+                <param-value>WEB-INF/classes/spring/auth-master.xml</param-value>
         </context-param>
 
         <listener>

--- a/fcrepo/4.7.4-demo/bin/entrypoint.sh
+++ b/fcrepo/4.7.4-demo/bin/entrypoint.sh
@@ -27,7 +27,8 @@ else
   fi
 fi
 
-OPTS="-Dfcrepo.log=${FCREPO_LOG_LEVEL}                                       \
+OPTS="-Dfcrepo.log=${FCREPO_LOG_LEVEL}
+      -Dfcrepo.log.auth=${FCREPO_AUTH_LOG_LEVEL}                             \
       -Dfcrepo.jms.baseUrl=${_JMS_BASEURL}                                   \
       -Dfcrepo.modeshape.configuration=${FCREPO_MODESHAPE_CONFIGURATION}     \
       -Dfcrepo.spring.configuration=${FCREPO_SPRING_CONFIGURATION}           \

--- a/fcrepo/4.7.4-demo/bin/setup_fedora.sh
+++ b/fcrepo/4.7.4-demo/bin/setup_fedora.sh
@@ -5,7 +5,7 @@ REPO="$1"
 LOG="setup_fedora.log"
 
 function wait_until_up {
-    CMD="curl --write-out %{http_code} --silent -o /dev/stderr ${REPO}"
+    CMD="curl -u bootstrap:bootstrap --write-out %{http_code} --silent -o /dev/stderr ${REPO}"
     echo "Waiting for response from Fedora via ${CMD}"
     RESULT=$(${CMD})
     until [ ${RESULT} -lt 400 ] && [ ${RESULT} -gt 199 ]
@@ -34,7 +34,7 @@ function create_binary {
     echo $msg
     echo -e "\n$msg\n" >> $LOG
     
-    curl -# -X PUT --upload-file "$file_path" -H "Content-Type: $content_type" "$repo_path" >> $LOG
+    curl -# -u bootstrap:bootstrap -X PUT --upload-file "$file_path" -H "Content-Type: $content_type" "$repo_path" >> $LOG
 
     if [ $? -ne 0 ]; then
 	echo "Failed"
@@ -55,7 +55,7 @@ function create_object {
     echo $msg
     echo -e "\n$msg\n" >> $LOG
 
-    curl -# -X PUT -H "Content-Type: text/turtle" "$repo_path" >> $LOG
+    curl -# -u bootstrap:bootstrap -X PUT -H "Content-Type: text/turtle" "$repo_path" >> $LOG
 
     if [ $? -ne 0 ]; then
 	echo "Failed"
@@ -70,8 +70,8 @@ function delete_object {
     echo $msg
     echo -e "\n$msg\n" >> $LOG
 
-    curl -X DELETE "$repo_path" >> $LOG
-    curl -X DELETE "$repo_path/fcr:tombstone" >> $LOG
+    curl -u bootstrap:bootstrap -X DELETE "$repo_path" >> $LOG
+    curl -u bootstrap:bootstrap -X DELETE "$repo_path/fcr:tombstone" >> $LOG
 }
 
 wait_until_up

--- a/fcrepo/4.7.4-demo/bin/setup_fedora.sh
+++ b/fcrepo/4.7.4-demo/bin/setup_fedora.sh
@@ -87,3 +87,7 @@ create_object "journals"
 create_object "publishers"
 create_object "deposits"
 create_object "workflows"
+
+curl -v -i -# -u bootstrap:bootstrap -X PUT -H "Content-Type: text/turtle" --data-binary "@conf/acl.ttl" ${REPO}/.acl
+curl -v -i -# -u bootstrap:bootstrap -X PUT -H "Content-Type: text/turtle" --data-binary "@conf/authz.ttl" ${REPO}/.acl/authz
+curl -v -i -# -u bootstrap:bootstrap -X PATCH -H "Content-Type: application/sparql-update" -d "INSERT { <> <http://www.w3.org/ns/auth/acl#accessControl> </fcrepo/rest/.acl> } WHERE {}" ${REPO}/

--- a/fcrepo/4.7.4-demo/conf/acl.ttl
+++ b/fcrepo/4.7.4-demo/conf/acl.ttl
@@ -1,0 +1,5 @@
+@prefix webac: <http://fedora.info/definitions/v4/webac#>.
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+
+<> a webac:Acl .
+

--- a/fcrepo/4.7.4-demo/conf/authz.ttl
+++ b/fcrepo/4.7.4-demo/conf/authz.ttl
@@ -1,0 +1,8 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+
+<> a acl:Authorization;
+acl:accessTo </fcrepo/rest/> ;
+acl:agent "fedoraUser" ;
+acl:mode acl:Read ;
+acl:mode acl:Write ;
+acl:mode acl:Append .

--- a/fcrepo/4.7.4-demo/conf/server.xml
+++ b/fcrepo/4.7.4-demo/conf/server.xml
@@ -113,7 +113,7 @@
     -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" tomcatAuthentication="false"/>
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" tomcatAuthentication="false" tomcatAuthorization="true"/>
 
 
     <!-- An Engine represents the entry point (within Catalina) that processes

--- a/fcrepo/4.7.4-demo/conf/server.xml
+++ b/fcrepo/4.7.4-demo/conf/server.xml
@@ -113,7 +113,7 @@
     -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" tomcatAuthentication="false"/>
 
 
     <!-- An Engine represents the entry point (within Catalina) that processes

--- a/fcrepo/4.7.4-demo/conf/tomcat-users.xml
+++ b/fcrepo/4.7.4-demo/conf/tomcat-users.xml
@@ -1,9 +1,11 @@
 <tomcat-users>
+  <!-- Create passwords with ./digest.sh -a sha-256 -h org.apache.catalina.realm.MessageDigestCredentialHandler [PASSWD] -->
   <role rolename="fedoraUser" />
   <role rolename="fedoraAdmin" />
-  <user name="admin" password="3a4384731fe845887c1307a668942ee37b516826a2c1085828a2e272bb71c544$1$36579ec0da60a5d1bbe0d6cde574400777b225e3e5939a8d5da9349d60020786" roles="fedoraAdmin" />
-  <user name="agudzun" password="c08a7d142bc26f7fadc8667083aa160ba7f3673c0809b9547edb62e1b119088e$1$366a735c8ac0ebbbc98ef20e9657d1339bb6540182eeb355137e5b6975a068c0" roles="fedoraAdmin" />
+  <user name="bootstrap" password="d643a7be407e3f39a924b147a84f48397af41fe465f65b8506daac6cd84904dd$1$0e6a64c63d54a053607b156d48a34fca1ddcaedca71d743b8635f21d50a14fb2" roles="fedoraAdmin" />
+  <user name="admin" password="3a4384731fe845887c1307a668942ee37b516826a2c1085828a2e272bb71c544$1$36579ec0da60a5d1bbe0d6cde574400777b225e3e5939a8d5da9349d60020786" roles="fedoraUser" />
+  <user name="agudzun" password="c08a7d142bc26f7fadc8667083aa160ba7f3673c0809b9547edb62e1b119088e$1$366a735c8ac0ebbbc98ef20e9657d1339bb6540182eeb355137e5b6975a068c0" roles="fedoraUser" />
   <user name="BenjaminHarman" password="c1894208115e79c594e7f133140e637fc4d8c8e8d43cff969f92261d8488988f$1$27bee1d70a6bd6d40d7862d23cfeb5836dc0edc47f78da0da42d6a781b471395" roles="fedoraUser" />
-  <user name="CynthiaSears" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraAdmin" />
+  <user name="CynthiaSears" password="27387daea77f878f82b46c7e323db3245ce2fa079ab2c6f6c410bcbac4cb7da5$1$84f7dcbeb8fff3fa1bbcd50b41f272eec890f21749ce774a03742fa2d3a7399b" roles="fedoraUser" />
   <user name="fedoraAdmin" password="53253a46e9f2f74e6a1141f654eb0cb4a71624d0493e7289489ada0c6255a1f0$1$4ab46c609603537a8665e0dde3a6aaadae24914cb4d8cff10084bb1a7a45c91e" roles="fedoraAdmin" />
 </tomcat-users>


### PR DESCRIPTION
* Uses fcrepo-webapp-plus to enable webac
* Makes regular users `fedoraUsers` role, rather than `fedoraAdmin` via `tomcat-users.xml`
* Adds a default acl granting r/w to `fedoraUsers`
